### PR TITLE
Fixing --ntasks-per-node flag in Distributed Pytorch Example 

### DIFF
--- a/Python/pytorch/Distributed/batch.sh
+++ b/Python/pytorch/Distributed/batch.sh
@@ -2,7 +2,7 @@
 #SBATCH --job-name pytorch
 #SBATCH -o %j.log
 #SBATCH -N 2
-#SBATCH --tasks-per-node=2
+#SBATCH --ntasks-per-node=2
 #SBATCH --gres=gpu:volta:2
 
 # Load modules


### PR DESCRIPTION
Updating incorrect sbatch flag in Distributed Pytorch job submission script. The flag is updated from "--tasks-per-node" to "--ntasks-per-node". 