### PR TITLE
Update param_sweep_parallel_v2.m

### DIFF
--- a/Matlab-Octave/Param_Sweep/Parallel/param_sweep_parallel_v2.m
+++ b/Matlab-Octave/Param_Sweep/Parallel/param_sweep_parallel_v2.m
@@ -18,7 +18,7 @@ n = 16; % number of independent iterations
 % Create Maps.
 map1 = 1;
 if (PARALLEL)
-    my_rank = pMATLAB.my_rank
+    my_rank = Pid
     % Break up rows.
     map1 = map([Np 1], {}, 0:Np-1 );
 end


### PR DESCRIPTION
Param Sweep example had some old syntax, updating `pMATLAB.my_rank` -> `Pid`